### PR TITLE
Allow NodejsFunction to be used without dependency on AWS

### DIFF
--- a/packages/@cdktf-plus/aws/lib/aws-event-bridge/snoop.ts
+++ b/packages/@cdktf-plus/aws/lib/aws-event-bridge/snoop.ts
@@ -1,7 +1,7 @@
 import { Resource, TerraformOutput, IAspect } from 'cdktf';
 import { IConstruct, Construct } from 'constructs';
 import { EventBridgeTarget } from './integration';
-import { NodejsFunction } from '../nodejs-function';
+import { NodejsLambdaFunction } from '../nodejs-lambda-function';
 import * as aws from '@cdktf/provider-aws';
 import * as path from 'path';
 
@@ -15,7 +15,7 @@ export class EventBridgeSnoop extends Resource {
 
     const { eventBridge } = props;
 
-    const lambda = new NodejsFunction(this, 'authorizer', {
+    const lambda = new NodejsLambdaFunction(this, 'authorizer', {
       path: path.join(__dirname, 'handler/index.ts'),
       logRetentionInDays: 1,
       memorySize: 128,

--- a/packages/@cdktf-plus/aws/lib/index.ts
+++ b/packages/@cdktf-plus/aws/lib/index.ts
@@ -3,4 +3,4 @@ export * from './aws-event-bridge';
 export * from './aws-iam';
 export * from './aws-lambda-function';
 export * from './docker-function';
-export * from './nodejs-function'
+export * from './nodejs-lambda-function'

--- a/packages/@cdktf-plus/aws/lib/nodejs-lambda-function/index.ts
+++ b/packages/@cdktf-plus/aws/lib/nodejs-lambda-function/index.ts
@@ -1,0 +1,53 @@
+import * as path from 'path';
+import { TerraformAsset, AssetType } from 'cdktf';
+import { Construct } from 'constructs';
+// This might be 10x slower than a native build - see https://esbuild.github.io/getting-started/#wasm
+import { buildSync } from 'esbuild-wasm';
+import { AwsLambdaFunction, AwsLambdaFunctionConfig } from '../aws-lambda-function';
+
+export interface NodejsLambdaFunctionConfig extends AwsLambdaFunctionConfig {
+  readonly path: string;
+  readonly external?: string[];
+}
+
+const bundle = (workingDirectory: string, entryPoint: string, external?: string[]) => {
+  buildSync({
+    entryPoints: [entryPoint],
+    platform: 'node',
+    target: 'es2018',
+    bundle: true,
+    format: 'cjs',
+    sourcemap: 'external',
+    external,
+    outdir: 'dist',
+    absWorkingDir: workingDirectory,
+  });
+
+  return path.join(workingDirectory, 'dist');
+};
+
+export class NodejsLambdaFunction extends AwsLambdaFunction {
+  public readonly asset: TerraformAsset;
+  public readonly bundledPath: string;
+
+  constructor(scope: Construct, id: string, config: NodejsLambdaFunctionConfig) {
+    const { path: filePath, ...rest } = config;
+    super(scope, id, rest);
+
+    const workingDirectory = path.resolve(path.dirname(config.path));
+    const distPath = bundle(workingDirectory, path.basename(config.path), config.external);
+    this.bundledPath = path.join(distPath, `${path.basename(config.path, '.ts')}.js`);
+
+    this.asset = new TerraformAsset(this, 'lambda-asset', {
+      path: distPath,
+      type: AssetType.ARCHIVE,
+    });
+
+    const fileName = path.basename(config.path, '.ts');
+
+    this.fn.handler = `${fileName}.handler`;
+    this.fn.filename = this.asset.path;
+    this.fn.sourceCodeHash = this.asset.assetHash;
+    this.fn.runtime = 'nodejs14.x';
+  }
+}

--- a/packages/@cdktf-plus/core/lib/index.ts
+++ b/packages/@cdktf-plus/core/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './custom-data-source';
 export * from './docker-asset';
+export * from './nodejs-function';

--- a/packages/@cdktf-plus/core/package.json
+++ b/packages/@cdktf-plus/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdktf-plus/core",
   "version": "0.0.0",
-  "description": "A collection of helpful L2 / L3 constrcuts for cdktf",
+  "description": "A collection of helpful L2 / L3 constructs for cdktf",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "publishConfig": {
@@ -41,12 +41,14 @@
     "@cdktf/provider-external": "^0.4.31",
     "@cdktf/provider-null": "^0.5.31",
     "docker-registry-client": "^3.3.0",
+    "esbuild-wasm": "^0.14.23",
     "execa": "^5.1.1",
     "hashdirectory": "^0.1.0"
   },
   "bundledDependencies": [
     "hashdirectory",
     "docker-registry-client",
+    "esbuild-wasm",
     "execa"
   ],
   "jsii": {


### PR DESCRIPTION
As discussed in Slack, the current version of `NodejsFunction` didn't work for my use case since it bundled the creation of an AWS Lambda and related assets, and I need to more tightly tune my Lambda configuration than this more generic construct allows. One potential solution is to rename the current `NodejsFunction` to `NodejsLambdaFunction` to signal that that is what it does -- it creates a new Lambda -- and to add a generic `NodejsFunction` that doesn't create any infrastructure but only takes care of bundling the code. The second feels like it belongs in `@cdktf-plus/core` since it doesn't have any AWS dependencies.

Note that this particular implementation isn't very DRY and I'm not sure if that's a good thing or a bad thing. We could have `NodejsLambdaFunction` reuse the code in `NodejsFunction` but that then more tightly couples the two packages. I don't feel strongly myself and could see us going either way.

Let me know if I missed anything else I should've changed! I've never personally worked with yarn before.