### PR TITLE
fix: depends on override is not properly escaped

### DIFF
--- a/packages/@cdktf-plus/core/lib/docker-asset/docker-asset.ts
+++ b/packages/@cdktf-plus/core/lib/docker-asset/docker-asset.ts
@@ -24,10 +24,10 @@ export class DockerAsset extends Resource {
       triggers: {
         folderhash: hashdirectory.sync(this.workingDirectory),
         name: this.repository.name
-      }
+      },
+      dependsOn: [this.repository.dependable]
     });
 
-    this.buildAndPush.addOverride('depends_on', [this.repository.dependable.fqn])
     this.dockerBuildCommand()
 
     this.dockerImage = new CustomDockerImage(this, 'image', {


### PR DESCRIPTION
If you used it with an override it leads to our [handling for dependencies](https://github.com/hashicorp/terraform-cdk/blob/3cf9fccfb10ce9370857e0931ade838beb35cd6a/packages/cdktf/lib/terraform-resource.ts#L68-L72) not being used